### PR TITLE
Fixing publishing feed bugs

### DIFF
--- a/honest/pricefeed_publish.py
+++ b/honest/pricefeed_publish.py
@@ -1670,7 +1670,10 @@ def execute(signal, log_in, auth, order):
             signed_tx = sign_transaction(tx, message)
         except Exception as e:
             trace(e)
-        signed_tx = verify_transaction(signed_tx)
+        try:
+            signed_tx = verify_transaction(signed_tx)
+        except Exception as e:
+            trace(e)
         if not DEV:
             enablePrint()
         broadcasted_tx = rpc_broadcast_transaction(signed_tx)


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/lib/python3.6/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/lib/python3.6/multiprocessing/process.py", line 93, in run
    self._target(*self._args, **self._kwargs)
  File "/root/Honest-MPA-Price-Feeds/honest/pricefeed_publish.py", line 1671, in execute
    signed_tx = verify_transaction(signed_tx)
UnboundLocalError: local variable 'signed_tx' referenced before assignment