### PR TITLE
Update CEX feeds

### DIFF
--- a/honest/HONEST.py
+++ b/honest/HONEST.py
@@ -105,10 +105,10 @@ def publish_feed(prices, name, wif):
     # these are fed reciprocal price feeds
     btsusdshort = dict(pub_dict)
     btsusdshort["asset_name"] = "HONEST.USDSHORT"
-    btsusdshort["settlement_price"] = 1.0/prices["feed"]["BTS:USD"]
+    btsusdshort["settlement_price"] = 1.0 / prices["feed"]["BTS:USD"]
     btsbtcshort = dict(pub_dict)
     btsbtcshort["asset_name"] = "HONEST.BTCSHORT"
-    btsbtcshort["settlement_price"] = 1.0/prices["feed"]["BTS:BTC"]
+    btsbtcshort["settlement_price"] = 1.0 / prices["feed"]["BTS:BTC"]
     # add each publication edict to the edicts list
     edicts = [
         btscny,
@@ -166,6 +166,8 @@ def gather_data(name, wif, trigger):
     dex = {}
     # wait until the first dex pricefeed writes to file
     while dex == {}:
+        time.sleep(0.5)
+        # Above prevents hard drive strain and allows `pricefeed_dex` to actually start
         dex = race_read_json("pricefeed_dex.txt")
     updates = 1
     while True:
@@ -273,7 +275,9 @@ def gather_data(name, wif, trigger):
                 sceletus_orders, sceletus_output = sceletus(
                     prices, name, wif, trigger["sceletus"]
                 )
-                race_append("sceletus_orders.txt", ("\n\n" + json_dumps(sceletus_orders)))
+                race_append(
+                    "sceletus_orders.txt", ("\n\n" + json_dumps(sceletus_orders))
+                )
                 race_write("sceletus_output.txt", json_dumps(sceletus_output))
 
             appendage = (

--- a/honest/add_producer.py
+++ b/honest/add_producer.py
@@ -49,12 +49,15 @@ ASSET_IDS = [
 # 1.19.65   1.3.5938    HONEST.BTCUSDMM
 # 1.19.66   1.3.5939    HONEST.BTCBTSMM
 
+
 def add_producer(name, wif):
     """
     update authorized feed producers with broker(order) method
     """
     for asset_id in ASSET_IDS:
-        nodes = ["wss://api.bts.mobi/wss",]
+        nodes = [
+            "wss://api.bts.mobi/wss",
+        ]
         header = {
             "account_name": name,
             "wif": wif,

--- a/honest/cancel_all_markets.py
+++ b/honest/cancel_all_markets.py
@@ -70,7 +70,9 @@ def main():
             print("           *****************")
             time.sleep(2)
             order = {
-                "edicts": [{"op": "cancel", "ids": orders},],
+                "edicts": [
+                    {"op": "cancel", "ids": orders},
+                ],
                 "header": {
                     "asset_id": "1.3.1",  # placeholder
                     "currency_id": "1.3.1",  # placeholder
@@ -102,7 +104,9 @@ def cancel_all_markets(account_name, wif):
         orders.sort()
         if orders:
             order = {
-                "edicts": [{"op": "cancel", "ids": orders},],
+                "edicts": [
+                    {"op": "cancel", "ids": orders},
+                ],
                 "header": {
                     "asset_id": "1.3.1",  # placeholder
                     "currency_id": "1.3.1",  # placeholder

--- a/honest/config_apikeys.py
+++ b/honest/config_apikeys.py
@@ -2,6 +2,7 @@
 this will be imported by various forex scripts which require api keys
 """
 
+
 def config_apikeys():
     """
     enter your api keys here for additional data sources, get keys at:
@@ -16,17 +17,15 @@ def config_apikeys():
     also enter your jsonbin.io key, id, and url here
     """
     return {
-
         "barchart": "",
         "fscapi": "",
         "fixerio": "",
         "currencyconverter": "",
         "fxmarket": "",
-        "openexchangerates":"",
-
-        "jsonbin":{
-            "key":"",
-            "id":"",
-            "url":"https://api.jsonbin.io/b/<your id here>/latest" # just for reference
+        "openexchangerates": "",
+        "jsonbin": {
+            "key": "",
+            "id": "",
+            "url": "https://api.jsonbin.io/b/<your id here>/latest",  # just for reference
         },
     }

--- a/honest/config_nodes.py
+++ b/honest/config_nodes.py
@@ -27,7 +27,7 @@ def public_nodes():
         "wss://node1.deex.exchange/wss",
         "wss://api.btslebin.com/wss",
         "wss://api.bts.btspp.io:10100/ws",
-        "wss://singapore.bitshares.im/ws"
+        "wss://singapore.bitshares.im/ws",
     ]
 
 

--- a/honest/dex_manual_signing.py
+++ b/honest/dex_manual_signing.py
@@ -170,8 +170,18 @@ def sample_orders():
     # cancel all and place two buy orders
     order1 = {
         "edicts": [
-            {"op": "buy", "amount": 10.0, "price": 0.00000100, "expiration": 0,},
-            {"op": "buy", "amount": 30.0, "price": 0.00000150, "expiration": 0,},
+            {
+                "op": "buy",
+                "amount": 10.0,
+                "price": 0.00000100,
+                "expiration": 0,
+            },
+            {
+                "op": "buy",
+                "amount": 30.0,
+                "price": 0.00000150,
+                "expiration": 0,
+            },
         ],
         "header": {
             "asset_id": "1.3.0",
@@ -268,7 +278,7 @@ def global_constants():
     # ISO8601 timeformat; 'graphene time'
     ISO8601 = "%Y-%m-%dT%H:%M:%S%Z"
     # MAX is 4294967295; year 2106 due to 4 byte unsigned integer
-    END_OF_TIME = 4 * 10 ** 9  # about 75 years in future
+    END_OF_TIME = 4 * 10**9  # about 75 years in future
     # very little
     SATOSHI = decimal(0.00000001)
     # almost 1
@@ -336,7 +346,12 @@ def wss_query(params):
             # this is the 4 part format of EVERY rpc request
             # params format is ["location", "object", []]
             query = json_dumps(
-                {"method": "call", "params": params, "jsonrpc": "2.0", "id": 1,}
+                {
+                    "method": "call",
+                    "params": params,
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                }
             )
             # print(query)
             # ws is the websocket connection created by wss_handshake()
@@ -380,7 +395,10 @@ def rpc_fees():
         "database",
         "get_required_fees",
         [
-            [["1", {"from": str(account_id)}], ["2", {"from": str(account_id)}],],
+            [
+                ["1", {"from": str(account_id)}],
+                ["2", {"from": str(account_id)}],
+            ],
             "1.3.0",
         ],
     ]
@@ -403,11 +421,11 @@ def rpc_balances():
     # print(balances)
     for balance in balances:
         if balance["asset_id"] == currency_id:
-            currency = decimal(balance["amount"]) / 10 ** currency_precision
+            currency = decimal(balance["amount"]) / 10**currency_precision
         if balance["asset_id"] == asset_id:
-            assets = decimal(balance["amount"]) / 10 ** asset_precision
+            assets = decimal(balance["amount"]) / 10**asset_precision
         if balance["asset_id"] == "1.3.0":
-            bitshares = decimal(balance["amount"]) / 10 ** 5
+            bitshares = decimal(balance["amount"]) / 10**5
 
     # print(currency, assets, bitshares)
     return currency, assets, bitshares
@@ -889,18 +907,18 @@ class PublicKey(Address):  # graphenebase/account.py
 
     def __repr__(self):
         # print('PublicKey.__repr__')
-        """ Gives the hex representation of the Graphene public key. """
+        """Gives the hex representation of the Graphene public key."""
         return repr(self._pk)
 
     def __format__(self, _format):
         # print('PublicKey.__format__')
-        """ Formats the instance of:doc:`Base58 <base58>
-        ` according to ``_format`` """
+        """Formats the instance of:doc:`Base58 <base58>
+        ` according to ``_format``"""
         return format(self._pk, _format)
 
     def __bytes__(self):
         # print('PublicKey.__bytes__')
-        """ Returns the raw public key (has length 33)"""
+        """Returns the raw public key (has length 33)"""
         return bytes(self._pk)
 
 
@@ -909,8 +927,8 @@ class PrivateKey(PublicKey):  # merged litepresence2019
     # Bitshares(MIT) graphenebase/account.py
     # Bitshares(MIT) bitsharesbase/account.py
 
-    """ Derives the compressed and uncompressed public keys and
-        constructs two instances of ``PublicKey``:
+    """Derives the compressed and uncompressed public keys and
+    constructs two instances of ``PublicKey``:
     """
 
     def __init__(self, wif=None, prefix="BTS"):
@@ -955,7 +973,7 @@ class PrivateKey(PublicKey):  # merged litepresence2019
 
     def __bytes__(self):
         # print('PrivateKey.__bytes__')
-        """ Returns the raw private key """
+        """Returns the raw private key"""
         return bytes(self._wif)
 
 
@@ -985,7 +1003,10 @@ class Asset(GrapheneObject):  # bitsharesbase/objects.py
                 OrderedDict(
                     [
                         ("amount", Int64(kwargs["amount"])),
-                        ("asset_id", ObjectId(kwargs["asset_id"], "asset"),),
+                        (
+                            "asset_id",
+                            ObjectId(kwargs["asset_id"], "asset"),
+                        ),
                     ]
                 )
             )
@@ -1002,10 +1023,22 @@ class Limit_order_create(GrapheneObject):  # bitsharesbase/operations.py
                 OrderedDict(
                     [
                         ("fee", Asset(kwargs["fee"])),
-                        ("seller", ObjectId(kwargs["seller"], "account"),),
-                        ("amount_to_sell", Asset(kwargs["amount_to_sell"]),),
-                        ("min_to_receive", Asset(kwargs["min_to_receive"]),),
-                        ("expiration", PointInTime(kwargs["expiration"]),),
+                        (
+                            "seller",
+                            ObjectId(kwargs["seller"], "account"),
+                        ),
+                        (
+                            "amount_to_sell",
+                            Asset(kwargs["amount_to_sell"]),
+                        ),
+                        (
+                            "min_to_receive",
+                            Asset(kwargs["min_to_receive"]),
+                        ),
+                        (
+                            "expiration",
+                            PointInTime(kwargs["expiration"]),
+                        ),
                         ("fill_or_kill", Uint8(kwargs["fill_or_kill"])),
                         ("extensions", Array([])),
                     ]
@@ -1028,7 +1061,10 @@ class Limit_order_cancel(GrapheneObject):  # bitsharesbase/operations.py
                             "fee_paying_account",
                             ObjectId(kwargs["fee_paying_account"], "account"),
                         ),
-                        ("order", ObjectId(kwargs["order"], "limit_order"),),
+                        (
+                            "order",
+                            ObjectId(kwargs["order"], "limit_order"),
+                        ),
                         ("extensions", Array([])),
                     ]
                 )
@@ -1114,9 +1150,18 @@ class Signed_Transaction(GrapheneObject):  # merged litepresence2019
             super().__init__(
                 OrderedDict(
                     [
-                        ("ref_block_num", Uint16(kwargs["ref_block_num"]),),
-                        ("ref_block_prefix", Uint32(kwargs["ref_block_prefix"]),),
-                        ("expiration", PointInTime(kwargs["expiration"]),),
+                        (
+                            "ref_block_num",
+                            Uint16(kwargs["ref_block_num"]),
+                        ),
+                        (
+                            "ref_block_prefix",
+                            Uint32(kwargs["ref_block_prefix"]),
+                        ),
+                        (
+                            "expiration",
+                            PointInTime(kwargs["expiration"]),
+                        ),
                         ("operations", kwargs["operations"]),
                         ("extensions", kwargs["extensions"]),
                         ("signatures", kwargs["signatures"]),
@@ -1511,7 +1556,7 @@ def build_transaction(order):
     # REMOVE DUST EDICTS
     if DUST and len(create_edicts):
         ce = []
-        dust = DUST * 100000 / 10 ** asset_precision
+        dust = DUST * 100000 / 10**asset_precision
         for i in range(len(create_edicts)):
             if create_edicts[i]["amount"] > dust:
                 ce.append(create_edicts[i])
@@ -1542,17 +1587,17 @@ def build_transaction(order):
         # derive min_to_receive & amount_to_sell from price & amount
         # means SELLING currency RECEIVING assets
         if create_edicts[i]["op"] == "buy":
-            min_to_receive["amount"] = int(amount * 10 ** asset_precision)
+            min_to_receive["amount"] = int(amount * 10**asset_precision)
             min_to_receive["asset_id"] = asset_id
 
-            amount_to_sell["amount"] = int(amount * price * 10 ** currency_precision)
+            amount_to_sell["amount"] = int(amount * price * 10**currency_precision)
             amount_to_sell["asset_id"] = currency_id
         # means SELLING assets RECEIVING currency
         if create_edicts[i]["op"] == "sell":
-            min_to_receive["amount"] = int(amount * price * 10 ** currency_precision)
+            min_to_receive["amount"] = int(amount * price * 10**currency_precision)
             min_to_receive["asset_id"] = currency_id
 
-            amount_to_sell["amount"] = int(amount * 10 ** asset_precision)
+            amount_to_sell["amount"] = int(amount * 10**asset_precision)
             amount_to_sell["asset_id"] = asset_id
         # Limit_order_create fee ordered dictionary
         fee = OrderedDict([("amount", fees["create"]), ("asset_id", "1.3.0")])
@@ -1567,7 +1612,10 @@ def build_transaction(order):
                     ("min_to_receive", min_to_receive),  # OrderedDict
                     ("expiration", op_expiration),  # ISO8601
                     ("fill_or_kill", KILL_OR_FILL),  # bool
-                    ("extensions", [],),  # always empty list for our purpose
+                    (
+                        "extensions",
+                        [],
+                    ),  # always empty list for our purpose
                 ]
             ),
         ]

--- a/honest/dex_meta_node.py
+++ b/honest/dex_meta_node.py
@@ -110,7 +110,7 @@ def race_append(doc="", text=""):
     """
     iteration = 0
     while True:
-        sleep(0.0001 * iteration ** 2)
+        sleep(0.0001 * iteration**2)
         iteration += 1
         try:
             if iteration > 10:
@@ -140,7 +140,7 @@ def race_write(doc="", text=""):
         text = str(text)
     iteration = 0
     while True:
-        sleep(0.0001 * iteration ** 2)
+        sleep(0.0001 * iteration**2)
         iteration += 1
         try:
             with open(doc, "w+") as handle:
@@ -166,7 +166,7 @@ def race_read(doc=""):
     """
     iteration = 0
     while True:
-        sleep(0.0001 * iteration ** 2)
+        sleep(0.0001 * iteration**2)
         iteration += 1
         try:
             with open(doc, "r") as handle:
@@ -441,16 +441,16 @@ def rpc_open_orders(rpc, cache):
             else:
                 base_precision = cache["asset_precision"]
                 quote_precision = cache["currency_precision"]
-            base_amount /= 10 ** base_precision
-            quote_amount /= 10 ** quote_precision
+            base_amount /= 10**base_precision
+            quote_amount /= 10**quote_precision
             if base_id == cache["asset_id"]:
                 order_type = "sell"
                 price = quote_amount / base_amount
-                amount /= 10 ** base_precision
+                amount /= 10**base_precision
             else:
                 order_type = "buy"
                 price = base_amount / quote_amount
-                amount = (amount / 10 ** base_precision) / price
+                amount = (amount / 10**base_precision) / price
             orders.append(
                 {
                     "orderNumber": order["id"],

--- a/honest/plot_feeds.py
+++ b/honest/plot_feeds.py
@@ -34,7 +34,6 @@ ASSET_IDS = {
 DAYS = 275
 
 
-
 def get_data():
     """
     Using multiple requests,
@@ -85,7 +84,7 @@ def get_data():
                     asset_data[publisher][1] += blocks
                     failed = 0
                 except KeyError:
-                    failed +=1
+                    failed += 1
                     print(data["detail"], "failed", failed)
                     print(ASSET_IDS[asset], PUBLISHER_IDS[publisher])
                     # if 20 days of no data stop searching for this asset/producer
@@ -127,7 +126,7 @@ def main():
     print("\033c")
     print("GATHERING HONEST PRICE FEED HISTORICAL DATA...\n")
     honest_feeds = get_data()
-    #print(honest_feeds, "\n")
+    # print(honest_feeds, "\n")
     doc = str(int(time.time())) + "_" + str(DAYS) + ".txt"
     print("\nPRINTING DATA TO FILE:", doc, "\n")
     with open(doc, "w+") as handle:

--- a/honest/pricefeed_dex.py
+++ b/honest/pricefeed_dex.py
@@ -117,7 +117,7 @@ def race_append(doc="", text=""):  # DONE
     doc = PATH + "pipe/" + doc
     iteration = 0
     while True:
-        sleep(0.0001 * iteration ** 2)
+        sleep(0.0001 * iteration**2)
         iteration += 1
         try:
             if iteration > 10:
@@ -148,7 +148,7 @@ def race_write(doc="", text=""):  # DONE
         text = str(text)
     iteration = 0
     while True:
-        sleep(0.0001 * iteration ** 2)
+        sleep(0.0001 * iteration**2)
         iteration += 1
         try:
             with open(doc, "w+") as handle:
@@ -175,7 +175,7 @@ def race_read(doc=""):
     doc = PATH + "pipe/" + doc
     iteration = 0
     while True:
-        sleep(0.0001 * iteration ** 2)
+        sleep(0.0001 * iteration**2)
         iteration += 1
         try:
             with open(doc, "r") as handle:
@@ -549,7 +549,9 @@ def thresh(storage, process, epoch, pid, cache):
                         it("purple", btc_dict),
                     )  # json_dump(btc_dict, indent=0, sort_keys=True)))
                     print(
-                        "DEX BTS:USD", "%.16f" % usd, it("purple", usd_dict),
+                        "DEX BTS:USD",
+                        "%.16f" % usd,
+                        it("purple", usd_dict),
                     )
                     print(
                         "DEX BTC:USD",
@@ -593,7 +595,8 @@ def thresh(storage, process, epoch, pid, cache):
                         pass
                     try:
                         print(
-                            "SCELETUS  ", it("purple", sceletus_output),
+                            "SCELETUS  ",
+                            it("purple", sceletus_output),
                         )
                     except:
                         pass

--- a/honest/pricefeed_publish.py
+++ b/honest/pricefeed_publish.py
@@ -79,7 +79,7 @@ HEXDIGITS = "0123456789abcdefABCDEF"
 # ISO8601 timeformat; 'graphene time'
 ISO8601 = "%Y-%m-%dT%H:%M:%S%Z"
 # MAX is 4294967295; year 2106 due to 4 byte unsigned integer
-END_OF_TIME = 4 * 10 ** 9  # about 75 years in future
+END_OF_TIME = 4 * 10**9  # about 75 years in future
 # very little
 SATOSHI = decimal(0.00000001)
 # almost 1
@@ -141,7 +141,12 @@ def wss_query(params):
             # query is 4 element dict {"method":"", "params":"", "jsonrpc":"", "id":""}
             # params is 3 element list ["location", "object", []]
             query = json_dumps(
-                {"method": "call", "params": params, "jsonrpc": "2.0", "id": 1,}
+                {
+                    "method": "call",
+                    "params": params,
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                }
             )
             # print(query)
             # ws is the websocket connection created by wss_handshake()
@@ -407,7 +412,7 @@ class PointInTime:
         self.data = d
 
     def __bytes__(self):
-        """ # """
+        """#"""
         return pack("<I", from_iso_date(self.data))
 
 
@@ -422,7 +427,7 @@ def fraction(num):
         num *= 10
         den *= 10
         # escape when numerator is integer or denomenator approaches double long int
-        if (int(num) == num) or (den == 10 ** 14):
+        if (int(num) == num) or (den == 10**14):
             break
     # ensure numerator is now an integer
     num = int(num)
@@ -479,7 +484,7 @@ class Base58(object):
             raise ValueError("Error loading Base58 object")
 
     def __format__(self, _format):
-        """ # """
+        """#"""
         if _format.upper() != "BTS":
             print("Format %s unkown. You've been warned!\n" % _format)
         return _format.upper() + str(self)
@@ -504,7 +509,7 @@ class Base58(object):
 
 
 def base58decode(base58_str):
-    """ # """
+    """#"""
     print(it("green", "base58decode"))
     base58_text = bytes(base58_str, "ascii")
     n = 0
@@ -523,7 +528,7 @@ def base58decode(base58_str):
 
 
 def base58encode(hexstring):
-    """ # """
+    """#"""
     print(it("green", "base58encode"))
     byteseq = bytes(unhexlify(bytes(hexstring, "ascii")))
     n = 0
@@ -568,7 +573,7 @@ def doublesha256(s):
 
 
 def base58CheckEncode(version, payload):
-    """ # """
+    """#"""
     print(it("green", "base58CheckEncode"))
     print(payload, version)
     s = ("%.2x" % version) + payload
@@ -579,7 +584,7 @@ def base58CheckEncode(version, payload):
 
 
 def gphBase58CheckEncode(s):
-    """ # """
+    """#"""
     print(it("yellow", "gphBase58CheckEncode"))
     print(s)
     checksum = ripemd160(s)[:4]
@@ -588,7 +593,7 @@ def gphBase58CheckEncode(s):
 
 
 def base58CheckDecode(s):
-    """ # """
+    """#"""
     print(it("green", "base58CheckDecode"))
     print(s[:4])
     s = unhexlify(base58decode(s))
@@ -599,7 +604,7 @@ def base58CheckDecode(s):
 
 
 def gphBase58CheckDecode(s):
-    """ # """
+    """#"""
     print(it("yellow", "gphBase58CheckDecode"))
     print(s)
     s = unhexlify(base58decode(s))
@@ -677,9 +682,7 @@ class PublicKey(Address):  # graphenebase/account.py
             bytes(self), curve=ecdsa_SECP256k1
         ).pubkey.point
         x_str = ecdsa_util.number_to_string(p.x(), order)
-        return hexlify(bytes(chr(2 + (p.y() & 1)), "ascii") + x_str).decode(
-            "ascii"
-        )
+        return hexlify(bytes(chr(2 + (p.y() & 1)), "ascii") + x_str).decode("ascii")
 
     def unCompressed(self):
         """
@@ -808,7 +811,10 @@ class Asset(GrapheneObject):
                 OrderedDict(
                     [
                         ("amount", Int64(kwargs["amount"])),
-                        ("asset_id", ObjectId(kwargs["asset_id"], "asset"),),
+                        (
+                            "asset_id",
+                            ObjectId(kwargs["asset_id"], "asset"),
+                        ),
                     ]
                 )
             )
@@ -937,9 +943,18 @@ class Signed_Transaction(GrapheneObject):
             super().__init__(
                 OrderedDict(
                     [
-                        ("ref_block_num", Uint16(kwargs["ref_block_num"]),),
-                        ("ref_block_prefix", Uint32(kwargs["ref_block_prefix"]),),
-                        ("expiration", PointInTime(kwargs["expiration"]),),
+                        (
+                            "ref_block_num",
+                            Uint16(kwargs["ref_block_num"]),
+                        ),
+                        (
+                            "ref_block_prefix",
+                            Uint32(kwargs["ref_block_prefix"]),
+                        ),
+                        (
+                            "expiration",
+                            PointInTime(kwargs["expiration"]),
+                        ),
                         ("operations", kwargs["operations"]),
                         ("extensions", kwargs["extensions"]),
                         ("signatures", kwargs["signatures"]),
@@ -965,12 +980,12 @@ class Signed_Transaction(GrapheneObject):
         return hexlify(h[:20]).decode("ascii")
 
     def getOperationKlass(self):
-        """ # """
+        """#"""
         print("Signed_Transaction.get_operationKlass")
         return Operation
 
     def derSigToHexSig(self, s):
-        """ # """
+        """#"""
         print("Signed_Transaction.derSigToHexSig")
         s, junk = ecdsa_der.remove_sequence(unhexlify(s))
         if junk:
@@ -981,7 +996,7 @@ class Signed_Transaction(GrapheneObject):
         return "%064x%064x" % (x, y)
 
     def deriveDigest(self, chain):
-        """ # """
+        """#"""
         print("Signed_Transaction.deriveDigest")
         print(self, chain)
         # Do not serialize signatures
@@ -996,7 +1011,7 @@ class Signed_Transaction(GrapheneObject):
         self.data["signatures"] = sigs
 
     def verify(self, pubkeys=None, chain="BTS"):
-        """ # """
+        """#"""
         if pubkeys is None:
             pubkeys = []
         print(it("green", "###############################################"))
@@ -1228,12 +1243,12 @@ def build_transaction(order):
         )
         # adjust settlment price to graphene asset and currency precisions
         adj_settlement = (
-            edict["settlement_price"] * 10 ** asset_precision / 10 ** currency_precision
+            edict["settlement_price"] * 10**asset_precision / 10**currency_precision
         )
         if edict["currency_name"] == "BTS":
             adj_core = adj_settlement
         else:
-            adj_core = edict["core_price"] * 10 ** asset_precision / 10 ** 5
+            adj_core = edict["core_price"] * 10**asset_precision / 10**5
         # FEE ORDERED DICT
         # create publication fee ordered dict
         fee = OrderedDict([("amount", fees["publish"]), ("asset_id", "1.3.0")])
@@ -1254,7 +1269,12 @@ def build_transaction(order):
         c_base = int(fraction(adj_core)["base"] * edict["CER"])
         c_quote = fraction(adj_core)["quote"]
         # create a core-base price ordered dict
-        core_base = OrderedDict([("amount", c_base), ("asset_id", asset_id),])
+        core_base = OrderedDict(
+            [
+                ("amount", c_base),
+                ("asset_id", asset_id),
+            ]
+        )
         # create a quote price ordered dict used w/ core base
         core_quote = OrderedDict([("amount", c_quote), ("asset_id", "1.3.0")])
         # combine core base and quote price
@@ -1267,7 +1287,7 @@ def build_transaction(order):
                     ("settlement_price", settlement_price),
                     (
                         "maintenance_collateral_ratio",
-                        edict["MCR"]  # use graphene precision
+                        edict["MCR"],  # use graphene precision
                     ),
                     ("maximum_short_squeeze_ratio", edict["MSSR"]),
                     ("core_exchange_rate", core_exchange_rate),

--- a/honest/utilities.py
+++ b/honest/utilities.py
@@ -80,7 +80,7 @@ def race_write(doc="", text=""):
     doc = PATH + "pipe/" + doc
     while True:
         try:
-            time.sleep(0.05 * i ** 2)
+            time.sleep(0.05 * i**2)
             i += 1
             with open(doc, "w+") as handle:
                 handle.write(text)
@@ -110,7 +110,7 @@ def race_read_json(doc=""):
     i = 0
     while True:
         try:
-            time.sleep(0.05 * i ** 2)
+            time.sleep(0.05 * i**2)
             i += 1
             with open(doc, "r") as handle:
                 data = json_loads(handle.read())


### PR DESCRIPTION
Changes:

- Update bittrex CEX feed for new API version 3, the old v1.1 API is deprecated as of 3/3/2022.
- Add gate.io CEX feed; API v4.
- Add 0.5 sec pause in HONEST.py to prevent hard drive stress and give metanode a chance to write data.
- Remove huobi CEX feed from BTS:BTC feed list, huobi no longer offers this feed.
- Increase `TIMEOUT` in pricefeed_cex.py from 10 sec to 15 sec to allow for slower connections.
- Add note in pricefeed_cex.py that binance must be run on a non-USA ip or vpn, otherwise BTS:BTC feed is not present. 
- Code linting.