### PR TITLE
Update HONEST.py

### DIFF
--- a/honest/HONEST.py
+++ b/honest/HONEST.py
@@ -41,7 +41,7 @@ from utilities import (PATH, it, logger, print_logo, race_append,
 CER = 1.5  # encourage payment of fees in bts, else 1.5X profit for HONEST producers
 MCR = 1400  # min. debt/collateral = 1.4
 MSSR = 1100  # liquidate immediately to as low as 1000/1100 = 11.0% below price feed
-REFRESH = 2750  # maintain accurate timely price feeds; approximately on 55 min
+REFRESH = 3240  # maintain accurate timely price feeds; approximately on 55 min
 # ######################################################################################
 # TRADEMARK HONEST MPA litepresence2020 - BDFL
 # ######################################################################################


### PR DESCRIPTION
Price scripts needs around 20-30s to complete. To maintan 55min interval, refresh rate is set to 54min.

## Summary by Sourcery

Enhancements:
- Modify the REFRESH interval to ensure price scripts complete within the 55-minute target window